### PR TITLE
Add display order to page messages

### DIFF
--- a/admin/setup_page_msg_edit.asp
+++ b/admin/setup_page_msg_edit.asp
@@ -79,11 +79,10 @@ Dim	strCreatedDate, _
 	intLangID, _
 	bVisiblePrintMode, _
 	bLoginOnly, _
+	intDisplayOrder, _
 	strPageMsg
 
 Dim intFieldLen, _
-	intWrapAt, _
-	intWrapNum, _
 	intPageType
 
 
@@ -118,13 +117,14 @@ With rsPageMsg
 		intLangID = .Fields("LangID")
 		bVisiblePrintMode = .Fields("VisiblePrintMode")
 		bLoginOnly = .Fields("LoginOnly")
+		intDisplayOrder = .Fields("DisplayOrder")
 		strPageMsg = .Fields("PageMsg")
 	End If
 End With
 
 
 If Not bNew Then
-	Call makePageHeader(TXT_EDIT_PAGE_MESSAGE & "<br>" & strMsgTitle, TXT_EDIT_PAGE_MESSAGE & "<br>" & strMsgTitle, True, False, True, True)
+	Call makePageHeader(TXT_EDIT_PAGE_MESSAGE & strMsgTitle, TXT_EDIT_PAGE_MESSAGE & strMsgTitle, True, False, True, True)
 Else
 	Call makePageHeader(TXT_ADD_MESSAGE, TXT_ADD_MESSAGE, True, False, True, True)
 End If
@@ -132,53 +132,70 @@ End If
 %>
 
 <p style="font-weight:bold">[ <a href="<%=makeLinkB("setup.asp")%>"><%=TXT_RETURN_TO_SETUP%></a> | <a href="<%=makeLinkB("setup_page_msg.asp")%>"><%=TXT_RETURN_TO_MESSAGE_SETUP%></a>]</p>
-<form action="setup_page_msg_edit2.asp" method="post">
+<form action="setup_page_msg_edit2.asp" method="post" class="form-horizontal">
 <%=g_strCacheFormVals%>
 <%If Not bNew Then%>
 <input type="hidden" name="PageMsgID" value="<%=intPageMsgID%>">
 <%End If%>
-<table class="BasicBorder cell-padding-4">
-	<tr>
-		<th colspan="2" class="RevTitleBox"><%=TXT_USE_THIS_FORM%></th>
-	</tr>
+<div class="panel panel-default max-width-lg">
+	<div class="panel-heading">
+		<h2><%=TXT_USE_THIS_FORM%></h2>
+	</div>
+	<div class="panel-body no-padding">
+	<table class="BasicBorder cell-padding-4 full-width form-table inset-table responsive-table">
 <%If Not bNew Then%>
 	<tr>
-		<td class="FieldLabelLeft"><%=TXT_DATE_CREATED%></td>
-		<td><%=strCreatedDate%></td>
+		<td class="field-label-cell"><%=TXT_DATE_CREATED%></td>
+		<td class="field-data-cell"><%=strCreatedDate%></td>
 	</tr>
 	<tr>
-		<td class="FieldLabelLeft"><%=TXT_CREATED_BY%></td>
-		<td><%=strCreatedBy%></td>
+		<td class="field-label-cell"><%=TXT_CREATED_BY%></td>
+		<td class="field-data-cell"><%=strCreatedBy%></td>
 	</tr>
 	<tr>
-		<td class="FieldLabelLeft"><%=TXT_LAST_MODIFIED%></td>
-		<td><%=strModifiedDate%></td>
+		<td class="field-label-cell"><%=TXT_LAST_MODIFIED%></td>
+		<td class="field-data-cell"><%=strModifiedDate%></td>
 	</tr>
 	<tr>
-		<td class="FieldLabelLeft"><%=TXT_MODIFIED_BY%></td>
-		<td><%=strModifiedBy%></td>
+		<td class="field-label-cell"><%=TXT_MODIFIED_BY%></td>
+		<td class="field-data-cell"><%=strModifiedBy%></td>
 	</tr>
 <%End If%>
 	<tr>
-		<td class="FieldLabelLeft"><label for="MsgTitle"><%=TXT_MESSAGE_TITLE%></label> <span class="Alert">*</span></td>
-		<td><input type="text" name="MsgTitle" id="MsgTitle" value=<%=AttrQs(strMsgTitle)%> size="<%=TEXT_SIZE%>" maxlength="50"> 
-		<br><%=TXT_INST_MESSAGE_TITLE%></td>
+		<td class="field-label-cell"><label for="MsgTitle">
+			<%=TXT_MESSAGE_TITLE%></label> <span class="Alert">*</span>
+			<a data-toggle="popover" data-trigger="focus" title="" data-placement="top" data-content=<%=AttrQs(TXT_INST_MESSAGE_TITLE)%> tabindex="0" data-original-title=<%=AttrQs(TXT_HELP & TXT_COLON & TXT_MESSAGE_TITLE)%>
+			<span class="glyphicon glyphicon-question-sign SimulateLink"></span>
+			</a>
+		</td>
+		<td class="field-data-cell">
+			<input type="text" name="MsgTitle" id="MsgTitle" value=<%=AttrQs(strMsgTitle)%> size="<%=TEXT_SIZE%>" maxlength="50" class="form-control">
+		</td>
 	</tr>
 	<tr>
-		<td class="FieldLabelLeft"><%=TXT_PRINT_MODE%></td>
-		<td><label for="VisiblePrintMode"><input type="checkbox" name="VisiblePrintMode" id="VisiblePrintMode" <%If bVisiblePrintMode Then%>checked<%End If%>><%=TXT_INST_PRINT_MODE%></label></td>
+		<td class="field-label-cell"><%=TXT_PRINT_MODE%></td>
+		<td class="field-data-cell"><label for="VisiblePrintMode"><input type="checkbox" name="VisiblePrintMode" id="VisiblePrintMode" <%If bVisiblePrintMode Then%>checked<%End If%>><%=TXT_INST_PRINT_MODE%></label></td>
 	</tr>
 	<tr>
-		<td class="FieldLabelLeft"><%=TXT_LOGIN_ONLY%></td>
-		<td><label for="LoginOnly"><input type="checkbox" name="LoginOnly" id="LoginOnly" <%If bLoginOnly Then%>checked<%End If%>><%=TXT_INST_LOGIN_ONLY%></label></td>
+		<td class="field-label-cell"><%=TXT_LOGIN_ONLY%></td>
+		<td class="field-data-cell"><label for="LoginOnly"><input type="checkbox" name="LoginOnly" id="LoginOnly" <%If bLoginOnly Then%>checked<%End If%>><%=TXT_INST_LOGIN_ONLY%></label></td>
 	</tr>
+	<tr>
+		<td class="field-label-cell"><label for="DisplayOrder"><%=TXT_ORDER%></label></td>
+		<td class="field-data-cell">
+			<div class="form-inline">
+				<input type="text" size="4" maxlength="3" name="DisplayOrder" title=<%=AttrQs(TXT_ORDER)%> value=<%=AttrQs(intDisplayOrder)%> class="form-control">
+		    </div>
+		</td>
+	</tr>
+	
 <%
 	Call openSysLanguageListRst(True)
 %>
-<tr>
-	<td class="FieldLabelLeft"><%=TXT_LANGUAGE%> <span class="Alert">*</span></td>
-	<td><%=makeSysLanguageList(intLangID,"LangID",False,vbNullString)%></td>
-</tr>
+	<tr>
+		<td class="field-label-cell"><%=TXT_LANGUAGE%> <span class="Alert">*</span></td>
+		<td class="field-data-cell"><%=makeSysLanguageList(intLangID,"LangID",False,vbNullString)%></td>
+	</tr>
 <%
 	Call closeSysLanguageListRst()
 	
@@ -190,45 +207,40 @@ End If
 	End If
 %>
 	<tr>
-		<td class="FieldLabelLeft"><label for="PageMsg"><%=TXT_PAGE_MESSAGE%></label> <span class="Alert">*</span></td>
-		<td><span class="SmallNote"><%=TXT_INST_MAX_4000%>&nbsp;<%=TXT_HTML_ALLOWED%></span>
-		<br><textarea name="PageMsg" id="PageMsg" wrap="soft" rows="<%=getTextAreaRows(intFieldLen,5)%>" cols="<%=TEXTAREA_COLS%>"><%=strPageMsg%></textarea>
-		<br><%=TXT_INST_PAGE_MESSAGE%></td>
+		<td class="field-label-cell">
+			<label for="PageMsg"><%=TXT_PAGE_MESSAGE%></label> <span class="Alert">*</span>
+			<a data-toggle="popover" data-trigger="focus" title="" data-placement="top" data-content=<%=AttrQs(TXT_INST_PAGE_MESSAGE)%> tabindex="0" data-original-title=<%=AttrQs(TXT_HELP & TXT_COLON & TXT_PAGE_MESSAGE)%>
+			<span class="glyphicon glyphicon-question-sign SimulateLink"></span>
+			</a>
+		</td>
+		<td class="field-data-cell"><span class="SmallNote"><%=TXT_INST_MAX_4000%>&nbsp;<%=TXT_HTML_ALLOWED%></span>
+		<br><textarea name="PageMsg" id="PageMsg" wrap="soft" rows="<%=getTextAreaRows(intFieldLen,5)%>" cols="<%=TEXTAREA_COLS%>" class="form-control"><%=strPageMsg%></textarea>
+		</td>
 	</tr>
 <%
 	Set rsPageMsg = rsPageMsg.NextRecordset
 %>
 	<tr>
-		<td class="FieldLabelLeft"><%=TXT_VIEW & " - " & TXT_CIC%></td>
-		<td><%=TXT_INST_VIEW%>
-		<br>&nbsp;
-		<table class="NoBorder cell-padding-3">
+		<td class="field-label-cell"><%=TXT_VIEW & " - " & TXT_CIC%>
+			<a data-toggle="popover" data-trigger="focus" title="" data-placement="top" data-content=<%=AttrQs(TXT_INST_VIEW)%> tabindex="0" data-original-title=<%=AttrQs(TXT_HELP & TXT_COLON & TXT_VIEW & " - " & TXT_CIC)%>
+			<span class="glyphicon glyphicon-question-sign SimulateLink"></span>
+			</a>
+		</td>
+		<td class="field-data-cell">
+		<div class="row">
 <%
 	With rsPageMsg
-		intWrapAt = 1
-		intWrapNum = intWrapAt
 		While Not .EOF
-			If intWrapNum = intWrapAt Then
 %>
-			<tr>
+			<div class="col-lg-4 col-md-6 col-sm-6 col-xs-12">
+				<label for="CICViewType_<%=.Fields("ViewType")%>"><input name="CICViewType" id="CICViewType_<%=.Fields("ViewType")%>" type="checkbox" value="<%=.Fields("ViewType")%>"<%=Checked(.Fields("VIEW_SELECTED"))%><%If Not .Fields("CAN_EDIT") Then%> disabled<%End If%>> <%=.Fields("ViewName")%></label>
+			</div>
 <%
-			End If
-%>
-				<td><label for="CICViewType_<%=.Fields("ViewType")%>"><input name="CICViewType" id="CICViewType_<%=.Fields("ViewType")%>" type="checkbox" value="<%=.Fields("ViewType")%>"<%=Checked(.Fields("VIEW_SELECTED"))%><%If Not .Fields("CAN_EDIT") Then%> disabled<%End If%>>&nbsp;<%=.Fields("ViewName")%></label></td>
-<%
-			If intWrapNum > 0 Then
-				intWrapNum = intWrapNum - 1
-			Else
-%>
-			</tr>
-<%
-				intWrapNum = intWrapAt
-			End If
 			.MoveNext
 		Wend
 	End With
 %>
-		</table>
+		</div>
 		</td>
 	</tr>
 <%
@@ -236,36 +248,26 @@ End If
 	If Not rsPageMsg.EOF Then
 %>
 	<tr>
-		<td class="FieldLabelLeft"><%=TXT_VIEW & " - " & TXT_VOLUNTEER%></td>
-		<td><%=TXT_INST_VIEW%>
-		<br>&nbsp;
-		<table class="NoBorder cell-padding-3">
+		<td class="field-label-cell"><%=TXT_VIEW & " - " & TXT_VOLUNTEER%>
+			<a data-toggle="popover" data-trigger="focus" title="" data-placement="top" data-content=<%=AttrQs(TXT_INST_VIEW)%> tabindex="0" data-original-title=<%=AttrQs(TXT_HELP & TXT_COLON & TXT_VIEW & " - " & TXT_VOLUNTEER)%>
+			<span class="glyphicon glyphicon-question-sign SimulateLink"></span>
+			</a>
+		</td>
+		<td class="field-data-cell">
+		<div class="row">
 <%
-		With rsPageMsg
-			intWrapAt = 2
-			intWrapNum = intWrapAt
-			While Not .EOF
-				If intWrapNum = intWrapAt Then
+	With rsPageMsg
+		While Not .EOF
 %>
-			<tr>
+			<div class="col-lg-4 col-md-6 col-sm-6 col-xs-12">
+				<label for="VOLViewType_<%=.Fields("ViewType")%>"><input name="VOLViewType" id="VOLViewType_<%=.Fields("ViewType")%>" type="checkbox" value="<%=.Fields("ViewType")%>"<%=Checked(.Fields("VIEW_SELECTED"))%><%If Not .Fields("CAN_EDIT") Then%> disabled<%End If%>> <%=.Fields("ViewName")%></label>
+			</div>
 <%
-				End If
+			.MoveNext
+		Wend
+	End With
 %>
-				<td><label for="VOLViewType_<%=.Fields("ViewType")%>"><input name="VOLViewType" id="VOLViewType_<%=.Fields("ViewType")%>" type="checkbox" value="<%=.Fields("ViewType")%>"<%=Checked(.Fields("VIEW_SELECTED"))%><%If Not .Fields("CAN_EDIT") Then%> disabled<%End If%>>&nbsp;<%=.Fields("ViewName")%></label></td>
-<%
-				If intWrapNum > 0 Then
-					intWrapNum = intWrapNum - 1
-				Else
-%>
-			</tr>
-<%
-					intWrapNum = intWrapAt
-				End If
-				.MoveNext
-			Wend
-		End With
-%>
-		</table>
+		</div>
 		</td>
 	</tr>
 <%
@@ -273,103 +275,53 @@ End If
 	Set rsPageMsg = rsPageMsg.NextRecordset
 %>
 	<tr>
-		<td class="FieldLabelLeft"><%=TXT_PAGES%> <span class="Alert">*</span></td>
-		<td><%=TXT_INST_PAGES%>
+		<td class="field-label-cell"><%=TXT_PAGES%> <span class="Alert">*</span></td>
+		<td class="field-data-cell">
+			<p class="InfoMsg"><%=TXT_INST_PAGES%></p>
 <%
+	Dim strPageType
+
 	With rsPageMsg
 		If Not .EOF Then
-			intWrapAt = 2
-			intWrapNum = intWrapAt
 			intPageType = -1
 			While Not .EOF
 				If .Fields("PAGE_TYPE") <> intPageType Then
-					If intWrapNum <> intWrapAt Then
-						While intWrapNum >= 0
+					If intPageType <> -1 Then
 %>
-				<td>&nbsp;</td>
-<%
-						intWrapNum = intWrapNum - 1
-						Wend
-%>
-			</tr>
+				</div>
+			</div>
+		</div>
 <%
 					End If
-					intWrapNum = intWrapAt
 					Select Case .Fields("PAGE_TYPE")
 						Case DM_GLOBAL
-							If intPageType <> -1 Then
-%>
-		</table>
-<%
-							End If
-%>
-		<br>&nbsp;
-		<table class="BasicBorder cell-padding-3">
-			<tr>
-				<th class="RevTitleBox" colspan="<%=intWrapAt+1%>"><%=TXT_SHARED%></th>
-			</tr>
-<%
+							strPageType = TXT_SHARED
 						Case DM_CIC
-							If intPageType <> -1 Then
-%>
-		</table>
-<%
-							End If
-%>
-		<br>&nbsp;
-		<table class="BasicBorder cell-padding-3">
-			<tr>
-				<th class="RevTitleBox" colspan="<%=intWrapAt+1%>"><%=TXT_CIC%></th>
-			</tr>
-<%
+							strPageType = TXT_CIC
 						Case DM_VOL
-							If intPageType <> -1 Then
-%>
-		</table>
-<%
-							End If
-%>
-		<br>&nbsp;
-		<table class="BasicBorder cell-padding-3">
-			<tr>
-				<th class="RevTitleBox" colspan="<%=intWrapAt+1%>"><%=TXT_VOLUNTEER%></th>
-			</tr>
-<%
+							strPageType = TXT_VOLUNTEER
 					End Select
-				End If
-
-				If intWrapNum = intWrapAt Then
 %>
-			<tr>
+		<div class="panel panel-default">
+			<div class="panel-heading"><h2><%=strPageType%></h2></div>
+			<div class="panel-body">
+				<div class="row">
 <%
 				End If
 %>
-				<td<%If Not Nl(.Fields("PageTitle")) Then%> title=<%=AttrQs(.Fields("PageTitle"))%><%End If%>><label for="PageName<%=.Fields("PageName")%>"><input id="PageName<%=.Fields("PageName")%>" name="PageName" type="checkbox" value="<%=.Fields("PageName")%>"<%=Checked(.Fields("PAGE_SELECTED"))%><%If Not .Fields("CAN_EDIT") Then%> disabled<%End If%>>&nbsp;<%=.Fields("PageName")%></label></td>
+					<div class="col-lg-4 col-md-6 col-sm-6 col-xs-12"> 
 <%
-				If intWrapNum > 0 Then
-					intWrapNum = intWrapNum - 1
-				Else
 %>
-			</tr>
+						<label for="PageName<%=.Fields("PageName")%>" <%If Not Nl(.Fields("PageTitle")) Then%> title=<%=AttrQs(.Fields("PageTitle"))%><%End If%>><input id="PageName<%=.Fields("PageName")%>" name="PageName" type="checkbox" value=<%=AttrQs(.Fields("PageName"))%> <%=Checked(.Fields("PAGE_SELECTED"))%><%If Not .Fields("CAN_EDIT") Then%> disabled<%End If%>> <%=.Fields("PageName")%></label>
+					</div>
 <%
-					intWrapNum = intWrapAt
-				End If
 				intPageType = .Fields("PAGE_TYPE")
 				.MoveNext
 			Wend
-			If intWrapNum <> intWrapAt Then
-				While intWrapNum >= 0
 %>
-				<td>&nbsp;</td>
-<%
-				intWrapNum = intWrapNum - 1
-				Wend
-%>
-			</tr>
-<%
-			End If
-%>
-		</table>
+				</div>
+			</div>
+		</div>
 <%
 		End If
 	End With
@@ -377,12 +329,34 @@ End If
 		</td>
 	</tr>
 	<tr>
-		<td colspan="2"><input type="submit" value="<%=TXT_SUBMIT_UPDATES%>"><%If Not bNew Then%> <input type="submit" name="Submit" value="<%=TXT_DELETE%>"><%End If%> <input type="reset" value="<%=TXT_RESET_FORM%>"></td>
+		<td colspan="2">
+			<input type="submit" value="<%=TXT_SUBMIT_UPDATES%>" class="btn btn-default">
+			<%If Not bNew Then%> <input type="submit" name="Submit" value="<%=TXT_DELETE%>" class="btn btn-default"><%End If%>
+			<input type="reset" value="<%=TXT_RESET_FORM%>" class="btn btn-default"></td>
 	</tr>
+	</table>
 </table>
+</div>
 </form>
-
 <%
 Call makePageFooter(False)
 %>
+<script type="text/javascript">
+$(document).ready(function(){
+    $('[data-toggle="popover"]').popover();
+});
+</script>
+<script src='//cdn.tinymce.com/4/tinymce.min.js'></script>
+<script type="text/javascript">
+tinymce.init({
+	selector: '#PageMsg',
+	plugins: [
+		'advlist anchor autolink lists link image charmap print preview anchor',
+		'searchreplace visualblocks code fullscreen',
+		'insertdatetime media table contextmenu paste code'
+	],
+	toolbar: 'insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link anchor image',
+	schema: 'html5'
+});
+</script>
 <!--#include file="../includes/core/incClose.asp" -->

--- a/admin/setup_page_msg_edit2.asp
+++ b/admin/setup_page_msg_edit2.asp
@@ -42,6 +42,7 @@ Call setPageInfo(True, DM_GLOBAL, DM_GLOBAL, "../", "admin/", vbNullString)
 <!--#include file="../includes/core/incFooter.asp" -->
 <!--#include file="../text/txtMenu.asp" -->
 <% 'End Base includes %>
+<!--#include file="../includes/validation/incDisplayOrder.asp" -->
 <!--#include file="../text/txtPageMsg.asp" -->
 <%
 If Not user_bSuperUser Then
@@ -74,6 +75,8 @@ ElseIf Not IsIDType(intPageMsgID) Then
 Else
 	intPageMsgID = CLng(intPageMsgID)
 End If
+
+Call getDisplayOrder()
 
 If Request("Submit") = TXT_DELETE Then
 	Call goToPage("setup_page_msg_delete.asp","PageMsgID=" & intPageMsgID,vbNullString)
@@ -153,6 +156,7 @@ If Nl(strError) Then
 		.Parameters.Append .CreateParameter("@LangID", adInteger, adParamInput, 4, intLangID)
 		.Parameters.Append .CreateParameter("@VisiblePrintMode", adBoolean, adParamInput, 1, IIf(bVisiblePrintMode, SQL_TRUE, SQL_FALSE))
 		.Parameters.Append .CreateParameter("@LoginOnly", adBoolean, adParamInput, 1, IIf(bLoginOnly, SQL_TRUE, SQL_FALSE))
+		.Parameters.Append .CreateParameter("@DisplayOrder", adInteger, adParamInput, 1, intDisplayOrder)
 		.Parameters.Append .CreateParameter("@PageMsg", adVarWChar, adParamInput, 4000, strPageMsg)
 		.Parameters.Append .CreateParameter("@CICViewList", adLongVarChar, adParamInput, -1, strCICViewList)
 		.Parameters.Append .CreateParameter("@VOLViewList", adLongVarChar, adParamInput, -1, strVOLViewList)

--- a/python/cioc/core/modelstate.py
+++ b/python/cioc/core/modelstate.py
@@ -139,9 +139,9 @@ class CiocFormRenderer(FormRenderer):
 	def text(self, name, value=None, id=None, **attrs):
 		kw = {'maxlength': 200, 'size': const.TEXT_SIZE}
 		kw.update(attrs)
-		kw['size'] = min((kw['maxlength'], kw['size']))
+		kw['size'] = min((kw['maxlength']+1, kw['size']))
 		return FormRenderer.text(self, name, value, self._fix_id(id or name), **kw)
-
+	
 	def proto_url(self, name, value=None, id=None, **attrs):
 		kw = {
 			'type': 'text', 'maxlength': 150, 'size': const.TEXT_SIZE - 5,

--- a/python/cioc/web/admin/templates/pages/edit.mak
+++ b/python/cioc/web/admin/templates/pages/edit.mak
@@ -105,6 +105,11 @@ ${self.makeMgmtInfo(page)}
 </form>
 
 <%def name="bottomjs()">
+<script type="text/javascript">
+$(document).ready(function(){
+    $('[data-toggle="popover"]').popover();
+});
+</script>
 <script src='//cdn.tinymce.com/4/tinymce.min.js'></script>
 <script type="text/javascript">
 tinymce.init({

--- a/python/sql/core/Stored Procedures/dbo.sp_GBL_PageMsg_l.sql
+++ b/python/sql/core/Stored Procedures/dbo.sp_GBL_PageMsg_l.sql
@@ -10,10 +10,8 @@ AS
 SET NOCOUNT ON
 
 /*
-	Checked for Release: 3.1
 	Checked by: KL
-	Checked on: 28-Jan-2012
-	Action: NO ACTION REQUIRED
+	Checked on: 11-Sep-2018
 */
 
 DECLARE	@Error int
@@ -33,7 +31,7 @@ SELECT pm.PageMsgID, pm.MsgTitle
 		ON pm.LangID=sl.LangID
 WHERE pm.MemberID=@MemberID
 	AND sl.Active=1
-ORDER BY pm.MsgTitle
+ORDER BY pm.DisplayOrder, pm.MsgTitle
 
 RETURN @Error
 

--- a/python/sql/core/Stored Procedures/dbo.sp_GBL_PageMsg_u.sql
+++ b/python/sql/core/Stored Procedures/dbo.sp_GBL_PageMsg_u.sql
@@ -206,7 +206,7 @@ IF @Error = 0 BEGIN
 				WHERE (
 					PageMsgID = @PageMsgID
 					AND NOT EXISTS(SELECT * FROM @ViewIDs tm WHERE tm.Domain=2 AND tm.ViewType=VOL_View_PageMsg.ViewType)
-					AND NOT EXISTS(SELECT * FROM CIC_View vw WHERE vw.ViewType=VOL_View_PageMsg.ViewType AND (ISNULL(vw.Owner,@AgencyCode)<>@AgencyCode))
+					AND NOT EXISTS(SELECT * FROM VOL_View vw WHERE vw.ViewType=VOL_View_PageMsg.ViewType AND (ISNULL(vw.Owner,@AgencyCode)<>@AgencyCode))
 				)
 			EXEC @Error =  cioc_shared.dbo.sp_STP_UnknownErrorCheck @@ERROR, @PageMessageObjectName, @ErrMsg
 			

--- a/python/sql/core/Stored Procedures/dbo.sp_GBL_PageMsg_u.sql
+++ b/python/sql/core/Stored Procedures/dbo.sp_GBL_PageMsg_u.sql
@@ -1,4 +1,3 @@
-
 SET QUOTED_IDENTIFIER ON
 GO
 SET ANSI_NULLS ON
@@ -15,6 +14,7 @@ CREATE PROCEDURE [dbo].[sp_GBL_PageMsg_u]
 	@LangID smallint,
 	@VisiblePrintMode bit,
 	@LoginOnly bit,
+	@DisplayOrder tinyint,
 	@PageMsg nvarchar(max),
 	@CICViewList varchar(max),
 	@VOLViewList varchar(max),
@@ -25,10 +25,8 @@ AS
 SET NOCOUNT ON
 
 /*
-	Checked for Release: 3.7.3
 	Checked by: KL
-	Checked on: 05-Jan-2016
-	Action: NO ACTION REQUIRED
+	Checked on: 11-Sep-2011
 */
 
 DECLARE	@Error	int
@@ -149,6 +147,7 @@ IF @Error = 0 BEGIN
 			LangID				= @LangID,
 			VisiblePrintMode	= ISNULL(@VisiblePrintMode, VisiblePrintMode),
 			LoginOnly			= ISNULL(@LoginOnly, LoginOnly),
+			DisplayOrder		= ISNULL(@DisplayOrder, DisplayOrder),
 			PageMsg				= @PageMsg
 		WHERE (PageMsgID = @PageMsgID)
 		EXEC @Error =  cioc_shared.dbo.sp_STP_UnknownErrorCheck @@ERROR, @PageMessageObjectName, @ErrMsg
@@ -163,6 +162,7 @@ IF @Error = 0 BEGIN
 			LangID,
 			VisiblePrintMode,
 			LoginOnly,
+			DisplayOrder,
 			PageMsg
 		) 
  		VALUES (
@@ -175,6 +175,7 @@ IF @Error = 0 BEGIN
 			@LangID,
 			ISNULL(@VisiblePrintMode,1),
 			ISNULL(@LoginOnly,0),
+			ISNULL(@DisplayOrder,0),
 			@PageMsg
 		)
 		EXEC @Error =  cioc_shared.dbo.sp_STP_UnknownErrorCheck @@ERROR, @PageMessageObjectName, @ErrMsg

--- a/python/sql/core/Tables/dbo.GBL_PageMsg.sql
+++ b/python/sql/core/Tables/dbo.GBL_PageMsg.sql
@@ -11,16 +11,14 @@ CREATE TABLE [dbo].[GBL_PageMsg]
 [PageMsg] [nvarchar] (max) COLLATE Latin1_General_100_CI_AI NOT NULL,
 [VisiblePrintMode] [bit] NOT NULL CONSTRAINT [DF_GBL_PageMsg_VisiblePrintMode] DEFAULT ((1)),
 [Bottom] [bit] NOT NULL CONSTRAINT [DF_GBL_PageMsg_Top] DEFAULT ((0)),
-[LoginOnly] [bit] NOT NULL CONSTRAINT [DF_GBL_PageMsg_LoginOnly] DEFAULT ((0))
-) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
-CREATE UNIQUE NONCLUSTERED INDEX [IX_GBL_PageMsg] ON [dbo].[GBL_PageMsg] ([MemberID], [MsgTitle]) ON [PRIMARY]
-
-
-
+[LoginOnly] [bit] NOT NULL CONSTRAINT [DF_GBL_PageMsg_LoginOnly] DEFAULT ((0)),
+[DisplayOrder] [tinyint] NOT NULL CONSTRAINT [DF_GBL_PageMsg_DisplayOrder] DEFAULT ((0))
+) ON [PRIMARY]
 GO
 ALTER TABLE [dbo].[GBL_PageMsg] ADD CONSTRAINT [PK_STP_Page_Message] PRIMARY KEY CLUSTERED  ([PageMsgID]) ON [PRIMARY]
 GO
-
+CREATE UNIQUE NONCLUSTERED INDEX [IX_GBL_PageMsg] ON [dbo].[GBL_PageMsg] ([MemberID], [MsgTitle]) ON [PRIMARY]
+GO
 ALTER TABLE [dbo].[GBL_PageMsg] ADD CONSTRAINT [FK_GBL_PageMsg_STP_Language] FOREIGN KEY ([LangID]) REFERENCES [dbo].[STP_Language] ([LangID]) ON DELETE CASCADE ON UPDATE CASCADE
 GO
 ALTER TABLE [dbo].[GBL_PageMsg] ADD CONSTRAINT [FK_GBL_PageMsg_STP_Member] FOREIGN KEY ([MemberID]) REFERENCES [dbo].[STP_Member] ([MemberID])


### PR DESCRIPTION
- add display order to page messages- 
- make page message editing mobile-friendly
- fix non-working help popovers on page editing
- fix display issue cutting off text on short fields when size=maxlength