### PR TITLE
Fix VOL Profile links show when not enabled in view

### DIFF
--- a/python/cioc/core/templates/layouts/volsearch_dualpanel.en_CA.html
+++ b/python/cioc/core/templates/layouts/volsearch_dualpanel.en_CA.html
@@ -143,7 +143,9 @@
 						[KEYWORD_SEARCH_IN]
 						</form>
 					</div>
+					[IF:USE_VOL_PROFILES_VIEW]
 					<p>A <strong><em>Volunteer Profile</em></strong> makes it easier to apply for positions, and can notify you of new positions that meet your criteria. [PROFILE_LINKS]
+					[ENDIF:USE_VOL_PROFILES_VIEW]
 					<p>Other Searching Resources:</p>
 					<ul>
 						<li><a href="[FN:MAKE_LINK]/volunteer/search1.asp[ENDFN:MAKE_LINK]" style="font-weight:bold;">Step-by-Step Search</a>

--- a/python/cioc/core/templates/layouts/volsearch_multipanel.en_CA.html
+++ b/python/cioc/core/templates/layouts/volsearch_multipanel.en_CA.html
@@ -173,7 +173,10 @@
 							[KEYWORD_SEARCH_IN]
 							</form>
 						</div>
+						[IF:USE_VOL_PROFILES_VIEW]
 						<p>A <strong><em>Volunteer Profile</em></strong> makes it easier to apply for positions, and can notify you of new positions that meet your criteria. [PROFILE_LINKS]
+						[ENDIF:USE_VOL_PROFILES_VIEW]
+
 						<p>Other Searching Resources:</p>
 						<ul>
 							<li><a href="[FN:MAKE_LINK]/volunteer/search1.asp[ENDFN:MAKE_LINK]" style="font-weight:bold;">Step-by-Step Search</a>

--- a/python/cioc/web/vol/bsearch.py
+++ b/python/cioc/web/vol/bsearch.py
@@ -334,6 +334,7 @@ class LayoutSearch(object):
 			'HAS_KEYWORD_SEARCH': not not search_info.BSrchKeywords,
 			'KEYWORD_SEARCH_BOX': kwargs['searchform_keyword'],
 			'KEYWORD_SEARCH_IN': kwargs['searchform_in_values'],
+			'USE_VOL_PROFILES_VIEW': not not (user and viewdata.UseProfilesView),
 			'PROFILE_LINKS': kwargs['searchform_profilelinks'],
 			'MAKE_LINK': template.make_linkify_fn(request),
 			'VIEWS_LIST': [{'VIEWTYPE': six.text_type(x.ViewType), 'VIEWNAME': x.ViewName} for x in self.viewslist] if self.viewslist else [],


### PR DESCRIPTION
The old format volunteer search form had a guard to prevent the
volunteer profiles links from being added if not configured in the view
but there was no construct to allow for that in more recent templates.

This change introduces the new `USE_VOL_PROFILES_VIEW` template variable
which encapsulates the logic from the old form to be used in newer
templates and applies that to a new if condition on the VOL Search Dual
Panel and Multi Panel templates.

See [here](
https://github.com/OpenCIOC/onlineresources/blob/master/python/cioc/web/vol/templates/bsearch.mak#L40
) for the old logic.